### PR TITLE
Add from_meshio as a separate step

### DIFF
--- a/meshplex/__init__.py
+++ b/meshplex/__init__.py
@@ -3,7 +3,7 @@ from .helpers import get_signed_simplex_volumes
 from .mesh_line import MeshLine
 from .mesh_tetra import MeshTetra
 from .mesh_tri import MeshTri
-from .reader import read
+from .reader import read, from_meshio
 
 __all__ = [
     "__version__",
@@ -11,5 +11,6 @@ __all__ = [
     "MeshTri",
     "MeshTetra",
     "read",
+    "from_meshio",
     "get_signed_simplex_volumes",
 ]

--- a/meshplex/reader.py
+++ b/meshplex/reader.py
@@ -20,15 +20,13 @@ def _sanitize(points, cells):
     return points, cells
 
 
-def read(filename):
-    """Reads an unstructured mesh into meshplex format.
+def from_meshio(mesh):
+    """Transform from meshio to meshplex format.
 
-    :param filenames: The files to read from.
-    :type filenames: str
+    :param mesh: The meshio mesh object.
+    :type mesh: meshio.Mesh
     :returns mesh{2,3}d: The mesh data.
     """
-    mesh = meshio.read(filename)
-
     # make sure to include the used nodes only
     tetra = mesh.get_cells_type("tetra")
     if len(tetra) > 0:
@@ -39,3 +37,13 @@ def read(filename):
     assert len(tri) > 0
     points, cells = _sanitize(mesh.points, tri)
     return MeshTri(points, cells)
+
+
+def read(filename):
+    """Reads an unstructured mesh into meshplex format.
+
+    :param filenames: The files to read from.
+    :type filenames: str
+    :returns mesh{2,3}d: The mesh data.
+    """
+    return from_meshio(meshio.read(filename))


### PR DESCRIPTION
Had a mesh object from `meshio` and wondered how to pass that over to `pyfvm`. I thought this would be a useful helper in order to not replicate the sanitize logic.